### PR TITLE
Add realtime voice webapp example

### DIFF
--- a/examples/realtime-webapp/README.md
+++ b/examples/realtime-webapp/README.md
@@ -1,0 +1,28 @@
+# Realtime Bland Voice Webapp Example
+
+This example demonstrates a simple browser interface that connects to a Bland AI Voice agent. Microphone access is requested from the user and transcripts for both sides of the conversation are displayed in realtime.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Provide your secrets as environment variables when running the server:
+
+- `BLAND_API_KEY` – your Bland API authorization key
+- `AGENT_ID` – the id of the voice agent you want to connect to
+
+## Running
+
+Start the local server with:
+
+```bash
+node server.js
+```
+
+The application will be available at [http://localhost:3000](http://localhost:3000).
+
+Click **Start Call** to initialize the conversation and **End Call** to stop it. New transcript lines will appear in the interface as they are received.

--- a/examples/realtime-webapp/app.js
+++ b/examples/realtime-webapp/app.js
@@ -1,0 +1,37 @@
+import { BlandWebClient } from '../../dist/lib/es6/index.js';
+
+const startBtn = document.getElementById('start');
+const stopBtn = document.getElementById('stop');
+const transcriptEl = document.getElementById('transcripts');
+
+let client = null;
+let transcripts = [];
+
+startBtn.addEventListener('click', async () => {
+  startBtn.disabled = true;
+  const resp = await fetch('/token');
+  const data = await resp.json();
+  if (data.error) {
+    alert('Failed to fetch token: ' + data.error);
+    startBtn.disabled = false;
+    return;
+  }
+  client = new BlandWebClient(data.agentId, data.token);
+  client.on('transcripts', tx => {
+    if (tx && tx.text) {
+      transcripts.push(tx);
+      transcriptEl.textContent = transcripts.map(t => `${t.type === 'user' ? 'User' : 'Agent'}: ${t.text}`).join('\n');
+    }
+  });
+  client.on('error', err => console.error('client error', err));
+  await client.initConversation({ sampleRate: 44100 });
+  stopBtn.disabled = false;
+});
+
+stopBtn.addEventListener('click', () => {
+  if (client) {
+    client.stopConversation();
+  }
+  stopBtn.disabled = true;
+  startBtn.disabled = false;
+});

--- a/examples/realtime-webapp/index.html
+++ b/examples/realtime-webapp/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bland Voice Realtime App</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #transcripts { margin-top: 20px; border: 1px solid #ccc; padding: 10px; height: 200px; overflow-y: auto; white-space: pre-line; }
+  </style>
+</head>
+<body>
+  <h1>Realtime Bland Voice Agent Demo</h1>
+  <button id="start">Start Call</button>
+  <button id="stop" disabled>End Call</button>
+  <div id="transcripts"></div>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/examples/realtime-webapp/package.json
+++ b/examples/realtime-webapp/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bland-realtime-webapp",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/examples/realtime-webapp/server.js
+++ b/examples/realtime-webapp/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+
+const AGENT_ID = process.env.AGENT_ID;
+const API_KEY = process.env.BLAND_API_KEY;
+
+const app = express();
+app.use(express.static(__dirname));
+
+app.get('/token', async (req, res) => {
+  if (!AGENT_ID || !API_KEY) {
+    res.status(500).json({ error: 'Missing AGENT_ID or BLAND_API_KEY env vars' });
+    return;
+  }
+  try {
+    const response = await fetch(`https://api.bland.ai/v1/agents/${AGENT_ID}/authorize`, {
+      method: 'POST',
+      headers: { 'Authorization': API_KEY }
+    });
+    const data = await response.json();
+    res.json({ token: data.token, agentId: AGENT_ID });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add `examples/realtime-webapp` demo
- implement a small Express server to fetch tokens
- create browser UI that streams audio to Bland AI and displays live transcripts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68499d4533908321943a9306692a1827